### PR TITLE
Bump version 4.9.18

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-b7d50d2ee11f415116c0fd03829d9577d25535a2  samba-4.9.13.tar.gz
+f47badc34273f73ae1f450df691e50e8c0387e4a  samba-4.9.18.tar.gz

--- a/ns-samba.spec
+++ b/ns-samba.spec
@@ -1,5 +1,5 @@
 Name: ns-samba
-Version: 4.9.13
+Version: 4.9.18
 Release: 1%{?dist}
 Summary: Samba vanilla build
 


### PR DESCRIPTION
Release notes (since our latest release)

- https://www.samba.org/samba/history/samba-4.9.18.html
- https://www.samba.org/samba/history/samba-4.9.17.html
- https://www.samba.org/samba/history/samba-4.9.16.html
- https://www.samba.org/samba/history/samba-4.9.15.html
- https://www.samba.org/samba/history/samba-4.9.14.html (last bugfix release of 4.9.x)
