### PR TITLE
Release 4.16.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ env:
     EVARS="
     -e DEST_ID -e TRAVIS_BRANCH -e TRAVIS_BUILD_ID -e TRAVIS_PULL_REQUEST_BRANCH
     -e TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG -e TRAVIS_TAG -e NSVER -e VERSIONS_PACK
-    -e STAGES_PACK"
+    -e STAGES_PACK -e YUM_ARGS=@development -e LANG=en_US.UTF-8"
 
 script: >
     docker run -ti --name makerpms ${EVARS}
     --hostname "b${TRAVIS_BUILD_NUMBER}.nethserver.org"
+    --volume $PWD/copr.repo:/etc/yum.repos.d/copr.repo
     --volume $PWD:/srv/makerpms/src:ro ${DOCKER_IMAGE} makerpms-travis -s *.spec | tee build.log
     && docker cp makerpms:/srv/makerpms/rpmbuild rpmbuild 
     && find rpmbuild -name 'ns-samba-*.rpm' | xargs -I FILE -- cp -v FILE .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     EVARS="
     -e DEST_ID -e TRAVIS_BRANCH -e TRAVIS_BUILD_ID -e TRAVIS_PULL_REQUEST_BRANCH
     -e TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG -e TRAVIS_TAG -e NSVER -e VERSIONS_PACK
-    -e STAGES_PACK -e YUM_ARGS=@development -e LANG=en_US.UTF-8"
+    -e STAGES_PACK -e YUM_ARGS=@development"
 
 script: >
     docker run -ti --name makerpms ${EVARS}

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ How to build
 
 2. Create needed tarballs ::
 
-    export sambaver=`grep sambaver ns-samba.spec | head -n 1 | awk '{print $3}'`
+    export sambaver=`grep Version ns-samba.spec | cut -d ':' -f 2 | tr -d ' '`
     git archive --format=tar --prefix=ns-samba-$sambaver/ HEAD | tar xf -
     tar -c -z --exclude-vcs --exclude='.gitignore' -f  ns-samba-$sambaver.tar.gz ns-samba-$sambaver
     rm -rf ns-samba-$sambaver

--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-4883593b724983e7fdf676b7a806bcd1cb6eafbc  samba-4.11.7.tar.gz
+5a77f1f4690fe32992fbd7a4dc2420338c6c2155  samba-4.16.5.tar.gz

--- a/copr.repo
+++ b/copr.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:sergiomb:SambaAD]
+name=Copr repo for SambaAD owned by sergiomb
+baseurl=https://download.copr.fedorainfracloud.org/results/sergiomb/SambaAD/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=0
+gpgkey=https://download.copr.fedorainfracloud.org/results/sergiomb/SambaAD/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/ns-samba.spec
+++ b/ns-samba.spec
@@ -1,5 +1,5 @@
 Name: ns-samba
-Version: 4.11.7
+Version: 4.16.5
 Release: 1%{?dist}
 Summary: Samba vanilla build
 
@@ -12,9 +12,9 @@ Source1: https://download.samba.org/pub/samba/stable/samba-%{version}.tar.gz
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
 BuildRequires: nethserver-devtools
-BuildRequires: python3-devel
+BuildRequires: python36-devel python36-markdown python36-dns
 BuildRequires: systemd-devel
-BuildRequires: gnutls-devel
+BuildRequires: compat-gnutls37-devel
 BuildRequires: docbook-xsl
 BuildRequires: libacl-devel
 BuildRequires: openldap-devel
@@ -22,6 +22,11 @@ BuildRequires: pam-devel
 BuildRequires: jansson-devel
 BuildRequires: gpgme-devel
 BuildRequires: libarchive-devel
+BuildRequires: flex
+BuildRequires: bison
+BuildRequires: zlib-devel
+BuildRequires: perl-Parse-Yapp  perl-JSON
+BuildRequires: popt-devel
 
 BuildRequires: systemd
 Requires(post): systemd
@@ -37,9 +42,10 @@ This is is a vanilla samba-%{version} build for NethServer 7
 %setup -q -D -T -b 1
 
 %build
+export LANG=en_US.UTF-8
 cd %{_builddir}/samba-%{version}
-%configure --with-systemd --enable-fhs --without-ldb-lmdb
-make %{?_smp_mflags}
+%configure --with-systemd --enable-fhs --without-ldb-lmdb --with-shared-modules='!vfs_snapper'
+LANG=en_US.UTF-8 make %{?_smp_mflags}
 
 %install
 rm -rf %{buildroot}

--- a/ns-samba.spec
+++ b/ns-samba.spec
@@ -22,8 +22,6 @@ BuildRequires: pam-devel
 BuildRequires: jansson-devel
 BuildRequires: gpgme-devel
 BuildRequires: libarchive-devel
-BuildRequires: flex
-BuildRequires: bison
 BuildRequires: zlib-devel
 BuildRequires: perl-Parse-Yapp  perl-JSON
 BuildRequires: popt-devel
@@ -42,10 +40,9 @@ This is is a vanilla samba-%{version} build for NethServer 7
 %setup -q -D -T -b 1
 
 %build
-export LANG=en_US.UTF-8
 cd %{_builddir}/samba-%{version}
 %configure --with-systemd --enable-fhs --without-ldb-lmdb --with-shared-modules='!vfs_snapper'
-LANG=en_US.UTF-8 make %{?_smp_mflags}
+make %{?_smp_mflags}
 
 %install
 rm -rf %{buildroot}

--- a/ns-samba.spec
+++ b/ns-samba.spec
@@ -40,6 +40,7 @@ This is is a vanilla samba-%{version} build for NethServer 7
 %setup -q -D -T -b 1
 
 %build
+export LANG=en_US.UTF-8
 cd %{_builddir}/samba-%{version}
 %configure --with-systemd --enable-fhs --without-ldb-lmdb --with-shared-modules='!vfs_snapper'
 make %{?_smp_mflags}


### PR DESCRIPTION
Add to mock:
```
config_opts['environment']['LANG'] = 'en_US.UTF-8'
os.environ.setdefault('LANG', 'C.UTF-8')
```

And also the COPR repo:
```
[copr:copr.fedorainfracloud.org:sergiomb:SambaAD]
name=Copr repo for SambaAD owned by sergiomb
baseurl=https://download.copr.fedorainfracloud.org/results/sergiomb/SambaAD/epel-7-$basearch/
type=rpm-md
skip_if_unavailable=True
gpgcheck=0
gpgkey=https://download.copr.fedorainfracloud.org/results/sergiomb/SambaAD/pubkey.gpg
repo_gpgcheck=0
enabled=1
enabled_metadata=1
```